### PR TITLE
Fixup redis w/ auth, and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ chat.
 
 ## Installing
 
-1. Add `hubot-markov-model` to your `package.json`:
+1. Add `hubot-markov` to your `package.json`:
 
 ```json
   "dependencies": {
-    "hubot-markov-model": "~1.2.0"
+    "hubot-markov": "~1.3.0"
   },
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hubot-markov",
   "description": "Build a markov model of everything Hubot hears.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": "Ash Wilson <smashwilson@gmail.com>",
 
   "contributors": [

--- a/src/markov.coffee
+++ b/src/markov.coffee
@@ -36,6 +36,10 @@ module.exports = (robot) ->
     process.env.BOXEN_REDIS_URL or
     'redis://localhost:6379'
   client = Redis.createClient(info.port, info.hostname)
+
+  if info.auth
+    client.auth info.auth.split(":")[1]
+
   storage = new RedisStorage(client)
 
   # Read markov-specific configuration from the environment.


### PR DESCRIPTION
This allows redis urls that require auth to work properly, as well as a version bump.

I also changed the README to reference the npm module name.
