### PR TITLE
`keyprefix` is now an instance var.

### DIFF
--- a/src/redis-storage.coffee
+++ b/src/redis-storage.coffee
@@ -3,7 +3,7 @@ class RedisStorage
 
   # Create a storage module that uses the provided Redis connection.
   # Keypreifx used to isolate stored markov transitions from other keys in the database.
-  constructor: (@client, @keyprefix="markov:") ->
+  constructor: (@client, @keyprefix = "markov:") ->
 
   # Uniformly and unambiguously convert an array of Strings and nulls into a valid
   # Redis key. Uses a length-prefixed encoding.
@@ -13,7 +13,7 @@ class RedisStorage
   _encode: (key) ->
     encoded = for part in key
       if part then "#{part.length}#{part}" else "0"
-    keyprefix + encoded.join('')
+    @keyprefix + encoded.join('')
 
   # Record a transition within the model. "transition.from" is an array of Strings and
   # nulls marking the prior state and "transition.to" is the observed next state, which


### PR DESCRIPTION
This fixes a stack trace the first time the model is populated:

```
[Thu Nov 19 2015 09:12:55 GMT-0500 (EST)] ERROR ReferenceError: keyprefix is not defined
  at RedisStorage._encode (/Users/ashl6947/code/hubot-markov/src/redis-storage.coffee:16:5, <js>:25:14)
  at RedisStorage.increment (/Users/ashl6947/code/hubot-markov/src/redis-storage.coffee:22:5, <js>:29:39)
  at MarkovModel.learn (/Users/ashl6947/code/hubot-markov/src/model.coffee:65:5, <js>:82:36)
  at /Users/ashl6947/code/hubot-markov/src/markov.coffee:79:28, <js>:57:13
  at Listener.callback (/Users/ashl6947/code/pushbot/node_modules/hubot/src/robot.coffee:233:52, <js>:158:16)
  at executeListener (/Users/ashl6947/code/pushbot/node_modules/hubot/src/listener.coffee:65:11, <js>:53:19)
  at allDone (/Users/ashl6947/code/pushbot/node_modules/hubot/src/middleware.coffee:41:37, <js>:32:16)
  at /Users/ashl6947/code/pushbot/node_modules/hubot/node_modules/async/lib/async.js:274:13
  at Object.async.eachSeries (/Users/ashl6947/code/pushbot/node_modules/hubot/node_modules/async/lib/async.js:142:20)
  at Object.async.reduce (/Users/ashl6947/code/pushbot/node_modules/hubot/node_modules/async/lib/async.js:268:15)
  at /Users/ashl6947/code/pushbot/node_modules/hubot/src/middleware.coffee:46:7, <js>:35:22
  at process._tickCallback (node.js:355:11)
```