### PR TITLE
Add hubot brain storage module

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The Hubot markov model can optionally be configured by setting environment varia
   * `memory`, the default, which stores transitions entirely in-process (lost on restart);
   * `redis`, which stores data in a Redis cache; or
   * `postgres`, which stores data in a PostgreSQL database.
+  * `hubot_brain`, store transitions in the hubot brain, useful when using other plugins like hubot-redis-brain
 
 * `HUBOT_MARKOV_STORAGE_URL` supplies additional configuration required by the `redis` and `postgres` storage backends. The formats are `redis://${USER}:${PASSWORD}@${HOSTNAME}:${PORT}/${DBNUM}` and `postgres://${USER}:${PASSWORD}@${HOSTNAME}:${PORT}/${DATABASE}` with defaults omitted.
 

--- a/src/storage/hubot-brain.coffee
+++ b/src/storage/hubot-brain.coffee
@@ -1,0 +1,18 @@
+MemoryStorage = require('./memory')
+
+# Markov storage implementation that uses built-in hubot brain
+class HubotBrainStorage extends MemoryStorage
+  constructor: (connStr, modelName, robot) ->
+    super connStr, modelName
+    @brain = robot.brain
+    @brainKey = 'markov-transitions-'+modelName
+    @brain.on 'loaded', =>
+      brainData = @brain.get @brainKey
+      @transitions = brainData unless !brainData?
+
+  incrementTransitions: (transitions, callback) ->
+    super transitions, () =>
+      @brain.set @brainKey, @transitions
+      process.nextTick callback
+
+module.exports = HubotBrainStorage

--- a/src/storage/index.coffee
+++ b/src/storage/index.coffee
@@ -2,3 +2,4 @@ module.exports =
   redis: require('./redis')
   postgres: require('./postgres')
   memory: require('./memory')
+  hubot_brain: require('./hubot-brain')


### PR DESCRIPTION
Add new hubot_brain storage option to use built-in hubot persistence.

This makes it so you can use other plugins to persist hubot (like hubot-redis-brain) as a whole.

You may want to consider making this default.