### PR TITLE
Add option to generate models per-user

### DIFF
--- a/src/config.coffee
+++ b/src/config.coffee
@@ -63,4 +63,7 @@ module.exports = (hash) ->
     ignoreMessageList: listSetting(hash, 'HUBOT_MARKOV_IGNORE_MESSAGE_LIST', [])
     learningListenMode: stringSetting(hash, 'HUBOT_MARKOV_LEARNING_LISTEN_MODE', 'catch-all')
     respondListenMode: stringSetting(hash, 'HUBOT_MARKOV_RESPOND_LISTEN_MODE', 'catch-all')
+    createUserModels: boolSetting(hash, 'HUBOT_MARKOV_CREATE_USER_MODELS', false)
+    userModelBlackList: listSetting(hash, 'HUBOT_MARKOV_USER_MODEL_BLACKLIST', [])
+    userModelWhiteList: listSetting(hash, 'HUBOT_MARKOV_USER_MODEL_WHITELIST', [])
   }


### PR DESCRIPTION
Add an option that enables this plugin to create per-user markov chains. It only allows forward generation for now. It will lazy-load chains as users post messages.

@smashwilson This is something I am playing around with. The default-listeners export was getting a big large and repetitive, so I broke some of it out into functions. Any comments on that? Going to fill it out with tests and more documentation before it becomes an official PR.