### PR TITLE
Fail over to environmental storage URL config

### DIFF
--- a/src/model-pool.coffee
+++ b/src/model-pool.coffee
@@ -40,7 +40,7 @@ class ModelPool
     else
       storageImpl = @defaultStorageImpl
 
-    storage = new storageImpl(options.storageUrl, name, @robot)
+    storage = new storageImpl(options.storageUrl or @config.storageUrl, name, @robot)
     storage.initialize (err) ->
       if err?
         queue.failed()


### PR DESCRIPTION
`ModelPool.createModel` is always called with empty config, so always breaks when using non-default storage URLs e.g. `HUBOT_MARKOV_STORAGE_URL=postgres://postgres:password@localhost:5432/hubot`.

This change keeps the current behaviour, but fails over to look up the instance config, which is provided from env vars and passed into the instance in the module root